### PR TITLE
fixed bug where delIndex was -1 if param followed by space but not \n

### DIFF
--- a/post/post.js
+++ b/post/post.js
@@ -87,9 +87,15 @@ module.exports = function(RED) {
                         for (j = 0; j < params.length; j++) {
                             result = result[params[j]];
                         }
+
+                        if (result) {
+                            result = result.toString();
+                            result = "\"" + result + "\"";
+                        }
+
                         replacements.push({
                                 "variable": "msg." + paramString,
-                                "val": result.toString()
+                                "value": result
                             }
                         );
                     }
@@ -97,7 +103,7 @@ module.exports = function(RED) {
 
                 for (r = 0; r < replacements.length; r++) {
                     var rep = replacements[r];
-                    cetext = cetext.replace(rep.variable, rep.val);
+                    cetext = cetext.replace(rep.variable, rep.value);
                 }
 
                 // Look for instances of {uid}

--- a/post/post.js
+++ b/post/post.js
@@ -61,10 +61,11 @@ module.exports = function(RED) {
                 var replacements = [];
                 for (i = 0; i < indices.length; i++) {
                     var msgIndex = indices[i];
-                    var delIndex = Math.min(
+                    var delIndex = leastPositiveIndex(
                         cetext.indexOf(" ", msgIndex),
                         cetext.indexOf("\n", msgIndex)
                     );
+
                     var paramString;
                     // Case 1: variable followed by space or new line
                     if (delIndex > -1) {
@@ -79,6 +80,7 @@ module.exports = function(RED) {
                         delIndex = cetext.length - 1;
                         paramString = cetext.substring(msgIndex + 4, delIndex);
                     }
+                    console.log(paramString);
                     if (paramString) {
                         var params = paramString.split(".");
                         var result = msg;
@@ -97,6 +99,11 @@ module.exports = function(RED) {
                     var rep = replacements[r];
                     cetext = cetext.replace(rep.variable, rep.val);
                 }
+
+                // Look for instances of {uid}
+                // If there are two, split sentences into the creation of the object and it's use
+                // Use the creation sentence for the first request...
+                // ... then use the response to gets its name and replace {uid} with it in the use sentence
 
                 ce += cetext;
 
@@ -195,4 +202,15 @@ function getOptions(options) {
     rtn += "&" + key + "=" + options[key];
     }
     return rtn;
+}
+
+function leastPositiveIndex(a, b) {
+    var output;
+    if (a >= 0 && b >= 0) {
+        output = Math.min(a, b);
+    }
+    else {
+        output = Math.max(a, b);
+    }
+    return output;
 }


### PR DESCRIPTION
Using Math.min to find the closest delimiter failed when the index of " " or "\n" was -1. Have replaced with a method that determines the correct value.